### PR TITLE
refactor(landing-page): responsive changes for xs screens

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -26,8 +26,10 @@ const StyledButton = styled(Button)`
       width: 230px;
     }
 
-    @media (max-width: 370px) {
-      width: 180px;
+    @media (max-width: 386px) {
+      width: 170px;
+      font-size: 16px;
+      line-height: 22px;
     }
   }
 `;

--- a/src/components/landing/hosted-by.js
+++ b/src/components/landing/hosted-by.js
@@ -12,6 +12,10 @@ const StyledThomsonReuters = styled.img`
   margin-top: 55px;
   width: 50%;
   position: relative;
+
+  @media (max-width: 768px) {
+    width: 80%;
+  }
 `;
 
 export default () => {

--- a/src/components/landing/internet-economy.js
+++ b/src/components/landing/internet-economy.js
@@ -58,6 +58,10 @@ const StyledSubtext = styled.div`
   @media (max-width: 510px) {
     font-size: 20px;
   }
+
+  @media (max-width: 386px) {
+    font-size: 16px;
+  }
 `;
 
 export default ({ language }) => {

--- a/src/components/landing/secret-sauce.js
+++ b/src/components/landing/secret-sauce.js
@@ -27,6 +27,17 @@ const SecretSauceHeading = styled.div`
   font-size: 36px;
   line-height: 49px;
   padding: 0px 60px;
+
+  @media (max-width: 768px) {
+    font-size: 24px;
+    line-height: 34px;
+  }
+
+  @media (max-width: 386px) {
+    font-size: 20px;
+    line-height: 22px;
+    padding: 0px 10px;
+  }
 `;
 const SecretSauceSubtext = styled.div`
   font-size: 16px;
@@ -37,6 +48,10 @@ const SecretSauceSubtext = styled.div`
   a {
     color: #4d00b4;
     text-decoration: underline;
+  }
+
+  @media (max-width: 386px) {
+    padding: 0px 0px;
   }
 `;
 


### PR DESCRIPTION
- Make headings and text smaller for xs screens
- Shrink button size to avoid getting out of alignment except in cases of extremely small screen sizes (<330px)