### PR TITLE
feat: link to escrow landing page

### DIFF
--- a/src/components/product-badges.js
+++ b/src/components/product-badges.js
@@ -19,7 +19,7 @@ import styles from "./styles/product-badges.module.css";
 const PNGToIcon = (alt, PNG) => (props) => <img alt={alt} src={PNG} {...props} />;
 const products = [
   { name: "Court", href: "https://court.kleros.io", Icon: Court },
-  { name: "Escrow", href: "https://escrow.kleros.io", Icon: Escrow },
+  { name: "Escrow", href: "https://kleros.io/escrow", Icon: Escrow },
   { name: "T2CR", href: "https://tokens.kleros.io", Icon: T2CR },
   { name: "Curate", href: "https://curate.kleros.io", Icon: Curate },
   { name: "Dispute Resolver", href: "https://resolve.kleros.io", Icon: DisputeResolver },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -396,7 +396,7 @@ class IndexPage extends React.Component {
                   <p className="text-center text-purple-darker ">Court</p>
                 </div>
                 <div className="d-inline-block">
-                  <a href="https://escrow.kleros.io">
+                  <a href="https://kleros.io/escrow">
                     <Badge>
                       <Escrow />
                     </Badge>


### PR DESCRIPTION
# Description

This PR makes the Escrow links go to the landing page, which was not being used anywhere.

# Rationale

There was no way to reach the Escrow landing page, and it provides useful information for people learning about our products.

# How To Test This?

Click on the two Escrow links—one on the home page and the other in the products navbar menu.
