### PR TITLE
updated dApps dropdown, added docs/about styles, asking to remove clg

### DIFF
--- a/src/components/styles/header.module.css
+++ b/src/components/styles/header.module.css
@@ -57,7 +57,9 @@
 
 .header .usecases div a,
 .header .research div a,
-.header .governance div a {
+.header .governance div a,
+.header .docs div a,
+.header .about div a {
   color: var(--color-gray) !important;
 }
 
@@ -96,7 +98,7 @@
   border: none;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 992px) {
   .header nav > div > div:nth-child(2) > div > div {
     margin-top: 1rem !important;
     min-width: fit-content;
@@ -121,7 +123,7 @@
   }
 
   .header nav div div:nth-child(1) button[class~="collapsed"]::after {
-    content: " ";
+    content: "";
     display: inline-block;
     border-top: 0.6ex solid transparent;
     border-bottom: 0.6ex solid transparent;
@@ -134,17 +136,18 @@
 }
 @media screen and (max-width: 992px) {
   .header nav div div:nth-child(1) button[class~="collapsed"]::after {
-    transform: rotate(90deg) translateX(0px);
+    transform: rotate(0deg) translateX(0px);
   }
 
   .header nav div div:nth-child(1) button::after {
-    content: " ";
+    content: "";
     display: inline-block;
     border-top: 0.6ex solid transparent;
     border-bottom: 0.6ex solid transparent;
     border-left: 0.6ex solid;
     vertical-align: middle;
     transform: translateY(-0.1rem);
+    transform: rotate(90deg) translateX(0px);
     margin-left: 0.5rem;
   }
 }
@@ -159,13 +162,15 @@
   text-align: right;
 }
 
-@media screen and (max-width: 992px) {
+/* 
+  Any specific code to be added here? Let me know!
+  @media screen and (max-width: 992px) {
   .header div > div:nth-child(2) > div > div {
   }
 
   .header div > div:nth-child(2) > div > a {
   }
-}
+} */
 
 .header svg {
   width: 3rem;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -267,6 +267,7 @@ class IndexPage extends React.Component {
     const { intl } = this.props;
 
     const { disputes, metaEvidences, subcourts, subcourtDetails, subcourtsExtra, loading, klerosCounters } = this.state;
+    // should the console logs be removed?
     console.log(this.state);
     console.log(EthereumInterface.Web3.utils.fromWei("123123123123123123"));
     return (


### PR DESCRIPTION
This PR tries to fix a UI bug that happens between screen sizes `768px` to `992px`. It also adds a few styling attributes in CSS that were supposedly missing for `docs` and `about` dropdowns.

Here's how it looked before:

https://user-images.githubusercontent.com/20269286/230291201-9601aaf6-2d4e-464c-b4eb-de3d4149e3e6.mp4


Here's how it looks after the fix:

https://user-images.githubusercontent.com/20269286/230291255-0717c66a-e83f-4ffe-86c8-d8e172cd7ceb.mp4


Before merging, I would like to have your review on the things below:

1. How should the dropdown's arrow icon react to clicks/collapse? I have edited the styling for `dApps` for your reference.
2. Should the style `className` IDs be different for `.usecases, .research, .governance, .docs, .about, etc. `? As they are displayed in a similar fashion, we can define just one class style for them.
3. If the `console.log()` are not required in `index.js`, I can remove them as well.
4. There were empty rulesets in the CSS file that I have modified, let me know what to do about them.

Thanks! : )