### PR TITLE
Typo fixed, Update bio.js

### DIFF
--- a/src/templates/bio.js
+++ b/src/templates/bio.js
@@ -93,12 +93,12 @@ export default ({ data }) => {
           </div>
           <div className={`mt-6 ${styles.buttonWrapper}`}>
             {frontmatter.report && (
-              <a style={{ margin: "8px" }} className="btn btn-primary" href={frontmatter.report} target="blank" rel="noopener noreferrer">
+              <a style={{ margin: "8px" }} className="btn btn-primary" href={frontmatter.report} target="_blank" rel="noopener noreferrer">
                 Download the Report
               </a>
             )}
             {frontmatter.spanishReport && (
-              <a style={{ margin: "8px" }} className="btn btn-primary" href={frontmatter.spanishReport} target="blank" rel="noopener noreferrer">
+              <a style={{ margin: "8px" }} className="btn btn-primary" href={frontmatter.spanishReport} target="_blank" rel="noopener noreferrer">
                 Descarga el reporte en Español
               </a>
             )}


### PR DESCRIPTION
Typo in `target="blank"`: In the anchor tag, the target attribute should use the standard value `_blank`, not `blank`.

Fixed.